### PR TITLE
Fix undefined index notice when the server does not have a signature

### DIFF
--- a/app/code/community/Ebanx/Gateway/Log/Environment.php
+++ b/app/code/community/Ebanx/Gateway/Log/Environment.php
@@ -43,7 +43,7 @@ class Ebanx_Gateway_Log_Environment
         $environment->interpreter->version = PHP_VERSION;
 
         $environment->web_server = new stdClass();
-        $environment->web_server->signature = $_SERVER['SERVER_SIGNATURE'];
+        $environment->web_server->signature = isset($_SERVER['SERVER_SIGNATURE']) ? $_SERVER['SERVER_SIGNATURE'] : '';
 
         $resource = Mage::getSingleton('core/resource');
         $conn = $resource->getConnection('externaldb_read');


### PR DESCRIPTION
If a webserver is configured to hide its signature a PHP notice about
an undefined index will be displayed in the error logs.

In Apache: ServerSignature Off
In Nginx: server_tokens off