### PR TITLE
Fix an issue with wrong totals when instalments are used

### DIFF
--- a/app/code/community/Ebanx/Gateway/Block/Adminhtml/Sales/Order/Creditmemo/Totals.php
+++ b/app/code/community/Ebanx/Gateway/Block/Adminhtml/Sales/Order/Creditmemo/Totals.php
@@ -16,7 +16,7 @@ class Ebanx_Gateway_Block_Adminhtml_Sales_Order_Creditmemo_Totals extends Mage_A
             $this->addTotalBefore(new Varien_Object(array(
                 'code'      => 'ebanx_interest',
                 'value'     => $amount,
-                'base_value'=> $amount,
+                'base_value'=> $amount / $this->getOrder()->getBaseToOrderRate(),
                 'label'     => $this->helper('ebanx')->__('Interest Amount'),
             ), array('tax')));
         }

--- a/app/code/community/Ebanx/Gateway/Block/Adminhtml/Sales/Order/Invoice/Totals.php
+++ b/app/code/community/Ebanx/Gateway/Block/Adminhtml/Sales/Order/Invoice/Totals.php
@@ -16,7 +16,7 @@ class Ebanx_Gateway_Block_Adminhtml_Sales_Order_Invoice_Totals extends Mage_Admi
             $this->addTotal(new Varien_Object(array(
                 'code'      => 'ebanx_interest',
                 'value'     => $amount,
-                'base_value'=> $amount,
+                'base_value'=> $amount / $this->getOrder()->getBaseToOrderRate(),
                 'label'     => $this->helper('ebanx')->__('Interest Amount'),
             )));
         }

--- a/app/code/community/Ebanx/Gateway/Block/Adminhtml/Sales/Order/Totals.php
+++ b/app/code/community/Ebanx/Gateway/Block/Adminhtml/Sales/Order/Totals.php
@@ -16,7 +16,7 @@ class Ebanx_Gateway_Block_Adminhtml_Sales_Order_Totals extends Mage_Adminhtml_Bl
             $this->addTotal(new Varien_Object(array(
                 'code'      => 'ebanx_interest',
                 'value'     => $amount,
-                'base_value'=> $amount,
+                'base_value'=> $amount / $this->getOrder()->getBaseToOrderRate(),
                 'label'     => $this->helper('ebanx')->__('Interest Amount'),
             ), array('tax')));
         }

--- a/app/code/community/Ebanx/Gateway/Model/Quote/Interest.php
+++ b/app/code/community/Ebanx/Gateway/Model/Quote/Interest.php
@@ -64,7 +64,9 @@ class Ebanx_Gateway_Model_Quote_Interest extends Mage_Sales_Model_Quote_Address_
         if ($interestAmount > 0) {
             $address->setEbanxInterestAmount($interestAmount);
             $address->setGrandTotal($address->getGrandTotal() + $interestAmount);
-            $address->setBaseGrandTotal($address->getBaseGrandTotal() + $interestAmount);
+            $address->setBaseGrandTotal(
+                $address->getBaseGrandTotal() + ($interestAmount / $quote->getBaseToQuoteRate())
+            );
         }
 
         return $this;


### PR DESCRIPTION
Hello,

We have an issue in our shop where orders processed with Ebanx that contain instalments have their totals messed up.

```
if ($interestAmount > 0) {
    $address->setEbanxInterestAmount($interestAmount);
    $address->setGrandTotal($address->getGrandTotal() + $interestAmount);
    $address->setBaseGrandTotal($address->getBaseGrandTotal() + $interestAmount);
}
```

The `setBaseGrandTotal` method is set with the interest amount in the original currency (e.g. BRL, MXN) rather than the base currency (e.g. EUR) therefore it has to be converted to the base currency amount.

```
$address->setBaseGrandTotal(
    $address->getBaseGrandTotal() + ($interestAmount / $quote->getBaseToQuoteRate())
);
```

This issue also exists in all the classes rewritten by the Ebanx module that add the `ebanx_interest` parcel to the totals:
- `Mage_Adminhtml_Block_Sales_Order_Totals`
- `Ebanx_Gateway_Block_Adminhtml_Sales_Order_Creditmemo_Totals`
- `Ebanx_Gateway_Block_Adminhtml_Sales_Order_Invoice_Totals`

These are all the places I could find to solve this issue. Please have a look to see if there are more situations where this can be an issue.

Best regards,
Ricardo